### PR TITLE
chore(SFT-1461): use custom id attributes when creating form anchors

### DIFF
--- a/src/freeform_next/Library/Composer/Components/Form.php
+++ b/src/freeform_next/Library/Composer/Components/Form.php
@@ -331,9 +331,10 @@ class Form implements \JsonSerializable, \Iterator, \ArrayAccess
     public function getAnchor()
     {
         $hash = $this->getHash();
-        $id   = substr(sha1($this->getId() . $this->getHandle()), 0, 6);
+        $id = $this->getCustomAttributes()->getId() ?? $this->getId();
+        $hashedId = substr(sha1($id . $this->getHandle()), 0, 6);
 
-        return "$id-form-$hash";
+        return "$hashedId-form-$hash";
     }
 
     /**


### PR DESCRIPTION
Users can now call the same form multiples on the same template, passing in unique `id`s.

`{exp:freeform_next:render form="contactUs" id="main"}`

`{exp:freeform_next:render form="contactUs" id="footer"}`
